### PR TITLE
Feature/activation suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ The prefix to be used for the Redis key under which file will be uploaded to Red
 
 *Default:* `context.project.name() + ':index'`
 
+### activationSuffix
+
+The suffix to be used for the Redis key under which the activated revision will be stored in Redis. By default this option will be `"current"`. This makes the default activated revision key in Redis looks like: `project.name() + ':index:current'`
+
+*Default:* `current`
+
 ### revisionKey
 
 The unique revision number for the version of the file being uploaded to Redis. The Redis key will be a combination of the `keyPrefix` and the `revisionKey`. By default this option will use either the `revisionKey` passed in from the command line or the `revisionData.revisionKey` property from the deployment context.

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = {
         keyPrefix: function(context){
           return context.project.name() + ':index';
         },
+        activationSuffix: 'current',
         didDeployMessage: function(context){
           var revisionKey = context.revisionData && context.revisionData.revisionKey;
           var activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
@@ -53,7 +54,7 @@ module.exports = {
         if (!this.pluginConfig.url) {
           ['host', 'port'].forEach(this.applyDefaultConfigProperty.bind(this));
         }
-        ['filePattern', 'distDir', 'keyPrefix', 'revisionKey', 'didDeployMessage', 'redisDeployClient'].forEach(this.applyDefaultConfigProperty.bind(this));
+        ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient'].forEach(this.applyDefaultConfigProperty.bind(this));
 
         this.log('config ok', { verbose: true });
       },
@@ -80,9 +81,10 @@ module.exports = {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var revisionKey       = this.readConfig('revisionKey');
         var keyPrefix         = this.readConfig('keyPrefix');
+        var activationSuffix  = this.readConfig('activationSuffix');
 
         this.log('Activating revision `' + revisionKey + '`', { verbose: true });
-        return Promise.resolve(redisDeployClient.activate(keyPrefix, revisionKey))
+        return Promise.resolve(redisDeployClient.activate(keyPrefix, revisionKey, activationSuffix))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function(){
             return {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -52,8 +52,8 @@ module.exports = CoreObject.extend({
       });
   },
 
-  activate: function(keyPrefix, revisionKey) {
-    var currentKey = keyPrefix + ':current';
+  activate: function(keyPrefix, revisionKey, activationSuffix) {
+    var currentKey = keyPrefix + ':' + activationSuffix;
 
     return Promise.resolve()
       .then(this._listRevisions.bind(this, keyPrefix))

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -199,13 +199,14 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 8);
+        assert.equal(messages.length, 9);
       });
       it('adds default config to the config object', function() {
         plugin.configure(context);
         assert.isDefined(config.redis.host);
         assert.isDefined(config.redis.port);
         assert.isDefined(config.redis.keyPrefix);
+        assert.isDefined(config.redis.activationSuffix);
         assert.isDefined(config.redis.didDeployMessage);
       });
     });
@@ -228,7 +229,7 @@ describe('redis plugin', function() {
         };
         plugin.beforeHook(context);
       });
-      it('warns about missing optional filePattern, distDir, revisionKey, didDeployMessage, and connection info', function() {
+      it('warns about missing optional filePattern, distDir, activationSuffix, revisionKey, didDeployMessage, and connection info', function() {
         plugin.configure(context);
         var messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
@@ -237,15 +238,56 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 7);
+        assert.equal(messages.length, 8);
       });
       it('does not add default config to the config object', function() {
         plugin.configure(context);
         assert.isDefined(config.redis.host);
         assert.isDefined(config.redis.port);
         assert.isDefined(config.redis.filePattern);
+        assert.isDefined(config.redis.activationSuffix);
         assert.isDefined(config.redis.didDeployMessage);
         assert.equal(config.redis.keyPrefix, 'proj:home');
+      });
+    });
+
+    describe('with an activationSuffix provided', function () {
+      var config, plugin, context;
+      beforeEach(function() {
+        config = {
+          redis: {
+            activationSuffix: 'special:suffix'
+          }
+        };
+        plugin = subject.createDeployPlugin({
+          name: 'redis'
+        });
+        context = {
+          ui: mockUi,
+          project: stubProject,
+          config: config
+        };
+        plugin.beforeHook(context);
+      });
+      it('warns about missing optional filePattern, distDir, keyPrefix, revisionKey, didDeployMessage, and connection info', function() {
+        plugin.configure(context);
+        var messages = mockUi.messages.reduce(function(previous, current) {
+          if (/- Missing config:\s.*, using default:\s/.test(current)) {
+            previous.push(current);
+          }
+
+          return previous;
+        }, []);
+        assert.equal(messages.length, 8)
+      });
+      it('does not add default config to the config object', function() {
+        plugin.configure(context);
+        assert.isDefined(config.redis.host);
+        assert.isDefined(config.redis.port);
+        assert.isDefined(config.redis.filePattern);
+        assert.isDefined(config.redis.keyPrefix);
+        assert.isDefined(config.redis.didDeployMessage);
+        assert.equal(config.redis.activationSuffix, 'special:suffix');
       });
     });
 
@@ -267,7 +309,7 @@ describe('redis plugin', function() {
         };
         plugin.beforeHook(context);
       });
-      it('warns about missing optional filePattern, distDir, keyPrefix, revisionKey and didDeployMessage only', function() {
+      it('warns about missing optional filePattern, distDir, keyPrefix, activationSuffix, revisionKey, and didDeployMessage only', function() {
         plugin.configure(context);
         var messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
@@ -276,7 +318,7 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 6);
+        assert.equal(messages.length, 7);
       });
 
       it('does not add default config to the config object', function() {

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -200,7 +200,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['a', 'b', 'c'];
 
-      var promise = redis.activate('key-prefix', 'c');
+      var promise = redis.activate('key-prefix', 'c', 'current');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redisKey, 'key-prefix:current');

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -172,7 +172,7 @@ describe('redis', function() {
   });
 
   describe('#activate', function() {
-    it('rejects if the revisionKey doesn\t exist in list of uploaded revisions', function() {
+    it('rejects if the revisionKey doesn\'t exist in list of uploaded revisions', function() {
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
         zrevrange: function() {
           return this.recentRevisions;


### PR DESCRIPTION
We have different staging environments reading from the same list of deployment revisions in a shared redis database. We'd like to be able to activate different revisions in the different staging environments from the same redis database.

Being able to configure the key for the currently activated revision (i.e., 1 key per staging environment) is an easy way to achieve this and also seems like a good enough idea anyway.