### PR TITLE
[WIP] Bugfix/list revisions activation suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,11 +65,12 @@ module.exports = {
         var distDir           = this.readConfig('distDir');
         var filePattern       = this.readConfig('filePattern');
         var keyPrefix         = this.readConfig('keyPrefix');
+        var activationSuffix  = this.readConfig('activationSuffix');
         var filePath          = path.join(distDir, filePattern);
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
         return this._readFileContents(filePath)
-          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, revisionKey))
+          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, activationSuffix, revisionKey))
           .then(this._uploadSuccessMessage.bind(this))
           .then(function(key) {
             return { redisKey: key };
@@ -106,9 +107,10 @@ module.exports = {
       fetchRevisions: function(context) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var activationSuffix = this.readConfig('activationSuffix');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix, activationSuffix))
           .then(function(revisions){
             return { revisions: revisions };
           })

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -33,20 +33,21 @@ module.exports = CoreObject.extend({
     this._allowOverwrite = options.allowOverwrite;
   },
 
-  upload: function(/*keyPrefix, revisionKey, value*/) {
+  upload: function(/*keyPrefix, activationSuffix, revisionKey, value*/) {
     var args = Array.prototype.slice.call(arguments);
 
-    var keyPrefix   = args.shift();
-    var value       = args.pop();
-    var revisionKey = args[0] || 'default';
-    var redisKey    = keyPrefix + ':' + revisionKey;
+    var keyPrefix        = args.shift();
+    var activationSuffix = args.shift();
+    var value            = args.pop();
+    var revisionKey      = args[0] || 'default';
+    var redisKey         = keyPrefix + ':' + revisionKey;
 
     var maxEntries = this._maxNumberOfRecentUploads;
 
     return Promise.resolve()
       .then(this._uploadIfKeyDoesNotExist.bind(this, redisKey, value))
       .then(this._updateRecentUploadsList.bind(this, keyPrefix, revisionKey))
-      .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries))
+      .then(this._trimRecentUploadsList.bind(this, keyPrefix, activationSuffix, maxEntries))
       .then(function() {
         return redisKey;
       });
@@ -61,10 +62,10 @@ module.exports = CoreObject.extend({
       .then(this._activateRevisionKey.bind(this, currentKey, revisionKey));
   },
 
-  fetchRevisions: function(keyPrefix) {
+  fetchRevisions: function(keyPrefix, activationSuffix) {
     return Promise.hash({
       revisions: this._listRevisions(keyPrefix),
-      current: this._activeRevision(keyPrefix)
+      current: this._activeRevision(keyPrefix, activationSuffix)
     }).then(function(results) {
         return results.revisions.map(function(revision) {
           return {
@@ -115,18 +116,18 @@ module.exports = CoreObject.extend({
     return client.zadd(listKey, score, revisionKey);
   },
 
-  _activeRevision: function(keyPrefix) {
-    var currentKey = keyPrefix + ':current';
+  _activeRevision: function(keyPrefix, activationSuffix) {
+    var currentKey = keyPrefix + ':' + activationSuffix;
     return this._client.get(currentKey);
   },
 
-  _trimRecentUploadsList: function(keyPrefix, maxEntries) {
+  _trimRecentUploadsList: function(keyPrefix, activationSuffix, maxEntries) {
     var client = this._client;
     var listKey = keyPrefix + ':revisions';
 
     return Promise.hash({
       revisionsToBeRemoved: client.zrange(listKey, 0, -(maxEntries + 1)),
-      current: this._activeRevision(keyPrefix)
+      current: this._activeRevision(keyPrefix, activationSuffix)
     }).then(function(results) {
       var revisions = results.revisionsToBeRemoved;
       var current = results.current;

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -379,7 +379,7 @@ describe('redis plugin', function() {
             revisionKey: '123abc',
             redisDeployClient: function(context) {
               return {
-                upload: function(keyPrefix, revisionKey) {
+                upload: function(keyPrefix, activationSuffix, revisionKey) {
                   return Promise.resolve(keyPrefix + ':' + revisionKey);
                 }
               };

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -19,7 +19,7 @@ describe('redis', function() {
     it('rejects if the key already exists in redis', function() {
       var redis = new Redis({}, new FakeRedis());
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', 'suffix', 'value');
       return assert.isRejected(promise, /^Value already exists for key: key:default$/);
     });
 
@@ -41,7 +41,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', 'suffix', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok(fileUploaded);
@@ -59,7 +59,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', 'suffix', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok(fileUploaded);
@@ -73,7 +73,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', 'suffix', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 1);
@@ -102,7 +102,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
 
-      var promise = redis.upload('key', '12', 'value');
+      var promise = redis.upload('key', 'suffix', '12', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 10);
@@ -115,7 +115,7 @@ describe('redis', function() {
 
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({
         get: function(key) {
-          if (key == 'key:current') {
+          if (key == 'key:suffix') {
             return Promise.resolve('1');
           }
           return Promise.resolve(null);
@@ -127,7 +127,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
 
-      var promise = redis.upload('key', '12', 'value');
+      var promise = redis.upload('key', 'suffix', '12', 'value');
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 11);
@@ -146,7 +146,7 @@ describe('redis', function() {
           }
         })));
 
-        var promise = redis.upload('key', 'value');
+        var promise = redis.upload('key', 'suffix', 'value');
         return assert.isRejected(promise)
           .then(function() {
             assert.equal(redisKey, 'key:default');
@@ -162,7 +162,7 @@ describe('redis', function() {
             }
         })));
 
-        var promise = redis.upload('key', 'tag', 'value');
+        var promise = redis.upload('key', 'suffix', 'tag', 'value');
         return assert.isRejected(promise)
           .then(function() {
             assert.equal(redisKey, 'key:tag');
@@ -181,7 +181,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['a', 'b', 'c'];
 
-      var promise = redis.activate('key-prefix', 'revision-key');
+      var promise = redis.activate('key-prefix', 'revision-key', 'key-suffix');
       return assert.isRejected(promise)
         .then(function(error) {
           assert.equal(error, '`revision-key` is not a valid revision key');
@@ -200,10 +200,10 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['a', 'b', 'c'];
 
-      var promise = redis.activate('key-prefix', 'c', 'current');
+      var promise = redis.activate('key-prefix', 'c', 'key-suffix');
       return assert.isFulfilled(promise)
         .then(function() {
-          assert.equal(redisKey, 'key-prefix:current');
+          assert.equal(redisKey, 'key-prefix:key-suffix');
           assert.equal(redisValue, 'c');
         });
     });


### PR DESCRIPTION
[My previous pull request][prev-pr] added support for the idea of an activationSuffix config option, so it didn't always have to be `current`. Allowing you to theoretically have many activations in one db.

What I didn't take into account was fetchRevisions. This PR adds support for activationSuffix to fetchRevisions so the current revision is derived from activationSuffix.

That has been dealt with in this PR, the WIP part is: I still haven't taken into account revision trimming with multiple activated revisions. At the moment it will trim based on your activationSuffix, so if you had activated with activationSuffix `currentSpecial` in the past, you could lose it in the future if you are uploading with trimming and a different activationSuffix.

Any suggestions here? You could theoretically have a key listing activation keys/suffixes but maybe there's a better way.

[prev-pr]: https://github.com/ember-cli-deploy/ember-cli-deploy-redis/pull/41