### PR TITLE
Add functionality to copy revision on activation. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ The unique revision number for the version of the file being uploaded to Redis. 
 
 *Default:* `context.commandLineArgs.revisionKey || context.revisionData.revisionKey`
 
+### activeContentSuffix
+
+The suffix to be used for the Redis key under which the activated revision content will be stored in Redis. By default this option will be `"current-content"`. This makes the default activated revision in Redis looks like: `project.name() + ':index:current-content'`
+
+This makes it possible to serve content completely from within NGINX using the [redis](https://www.nginx.com/resources/wiki/modules/redis/) module without doing a primary key lookup.
+
+```
+  server {
+    location / {
+      set $redis_key project-name:index:current-content;
+      redis_pass     name:6379;
+      default_type   text/html;
+    }
+  }
+```
+
+*Default:* `current-content`
+
 ### allowOverwrite
 
 A flag to specify whether the revision should be overwritten if it already exists in Redis.

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
           return context.project.name() + ':index';
         },
         activationSuffix: 'current',
+        activeContentSuffix: 'current-content',
         didDeployMessage: function(context){
           var revisionKey = context.revisionData && context.revisionData.revisionKey;
           var activatedRevisionKey = context.revisionData && context.revisionData.activatedRevisionKey;
@@ -62,7 +63,8 @@ module.exports = {
         if (!this.pluginConfig.url) {
           ['host', 'port'].forEach(this.applyDefaultConfigProperty.bind(this));
         }
-        ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient', 'maxRecentUploads'].forEach(this.applyDefaultConfigProperty.bind(this));
+
+        ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'activeContentSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient', 'maxRecentUploads'].forEach(this.applyDefaultConfigProperty.bind(this));
 
         this.log('config ok', { verbose: true });
       },
@@ -100,13 +102,14 @@ module.exports = {
       },
 
       activate: function(/* context */) {
-        var redisDeployClient = this.readConfig('redisDeployClient');
-        var revisionKey       = this.readConfig('revisionKey');
-        var keyPrefix         = this.readConfig('keyPrefix');
-        var activationSuffix  = this.readConfig('activationSuffix');
+        var redisDeployClient   = this.readConfig('redisDeployClient');
+        var revisionKey         = this.readConfig('revisionKey');
+        var keyPrefix           = this.readConfig('keyPrefix');
+        var activationSuffix    = this.readConfig('activationSuffix');
+        var activeContentSuffix = this.readConfig('activeContentSuffix');
 
         this.log('Activating revision `' + revisionKey + '`', { verbose: true });
-        return Promise.resolve(redisDeployClient.activate(keyPrefix, revisionKey, activationSuffix))
+        return Promise.resolve(redisDeployClient.activate(keyPrefix, revisionKey, activationSuffix, activeContentSuffix))
           .then(this.log.bind(this, '✔ Activated revision `' + revisionKey + '`', {}))
           .then(function(){
             return {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -52,13 +52,11 @@ module.exports = CoreObject.extend({
       });
   },
 
-  activate: function(keyPrefix, revisionKey, activationSuffix) {
-    var currentKey = keyPrefix + ':' + activationSuffix;
-
+  activate: function(keyPrefix, revisionKey, activationSuffix, activeContentSuffix) {
     return Promise.resolve()
       .then(this._listRevisions.bind(this, keyPrefix))
       .then(this._validateRevisionKey.bind(this, revisionKey))
-      .then(this._activateRevisionKey.bind(this, currentKey, revisionKey));
+      .then(this._activateRevision.bind(this, keyPrefix, revisionKey, activationSuffix, activeContentSuffix));
   },
 
   fetchRevisions: function(keyPrefix) {
@@ -90,9 +88,36 @@ module.exports = CoreObject.extend({
     return revisions.indexOf(revisionKey) > -1 ? Promise.resolve() : Promise.reject('`' + revisionKey + '` is not a valid revision key');
   },
 
-  _activateRevisionKey: function(currentKey, revisionKey) {
+  _activateRevisionKey: function(keyPrefix, revisionKey, activationSuffix) {
+    var currentKey = keyPrefix + ':' + activationSuffix;
+
+    return this._client.set(currentKey, revisionKey);
+  },
+
+  _activateRevision: function(keyPrefix, revisionKey, activationSuffix, activeContentSuffix) {
+    if (activeContentSuffix) {
+      return this._copyRevisionAndActivateRevisionKey(keyPrefix, revisionKey, activationSuffix, activeContentSuffix);
+    }
+
+    return this._activateRevisionKey(keyPrefix, revisionKey, activationSuffix);
+  },
+
+  _copyRevisionAndActivateRevisionKey: function(keyPrefix, revisionKey, activationSuffix, activeContentSuffix) {
     var client = this._client;
-    return client.set(currentKey, revisionKey);
+    var _this  = this;
+    var activeContentKey = keyPrefix + ':' + activeContentSuffix;
+    var revisionContentKey = keyPrefix + ':' + revisionKey;
+
+    return new Promise(function(resolve, reject) {
+      client.get(revisionContentKey).then(
+        function(value) {
+          client.set(activeContentKey, value).then(function() {
+            _this._activateRevisionKey(keyPrefix, revisionKey, activationSuffix).then(resolve, reject);
+          });
+        },
+        reject
+      ); 
+    });
   },
 
   _uploadIfKeyDoesNotExist: function(redisKey, value) {

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -271,7 +271,7 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 10);
+        assert.equal(messages.length, 11);
       });
       it('adds default config to the config object', function() {
         plugin.configure(context);
@@ -310,7 +310,7 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 9);
+        assert.equal(messages.length, 10);
       });
       it('does not add default config to the config object', function() {
         plugin.configure(context);
@@ -350,7 +350,7 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 9)
+        assert.equal(messages.length, 10)
       });
       it('does not add default config to the config object', function() {
         plugin.configure(context);
@@ -390,7 +390,7 @@ describe('redis plugin', function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 8);
+        assert.equal(messages.length, 9);
       });
 
       it('does not add default config to the config object', function() {


### PR DESCRIPTION
This pr adds a config option copyToKey. When defined the activate function copies the value of the specified version to the copyToKey in redis. This makes it possible to serve the index page from nginx.

```
// deploy.js (sync)
module.exports = function(environment){
  var ENV = {
  };

  if (environment === 'production') {
    Env.redis = {
      copyToKey: 'my-app:active-version'
    }
  };
  return ENV;
};
```
Here is the corresponding nginx config. 

```
#this sets a variable $app_version from a url parameter version or defaults to 'current-copy'
map $arg_version $app_version {
    default "active-version";
    ~^\w+ $arg_version;
}
upstream redisbackend{
    server 127.0.0.1:6379;
}
server {
    location / {
        set $redis_key my-app:$app_version;
        redis_pass redisbackend;
        default_type text/html;
    }
}
```