### PR TITLE
set previousRevisionKey before activating a new revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ For detailed information on what plugin hooks are and how they work, please refe
 
 - `configure`
 - `upload`
+- `willActivate`
 - `activate`
 - `didDeploy`
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,19 @@ module.exports = {
           .catch(this._errorMessage.bind(this));
       },
 
+      willActivate: function(/* context */) {
+        var redisDeployClient = this.readConfig('redisDeployClient');
+        var keyPrefix         = this.readConfig('keyPrefix');
+
+        var revisionKey = redisDeployClient.activeRevision(keyPrefix);
+        
+        return {
+          revisionData: {
+            previousRevisionKey: revisionKey
+          }
+        };
+      },
+
       activate: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var revisionKey       = this.readConfig('revisionKey');

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -64,7 +64,7 @@ module.exports = CoreObject.extend({
   fetchRevisions: function(keyPrefix) {
     return Promise.hash({
       revisions: this._listRevisions(keyPrefix),
-      current: this._activeRevision(keyPrefix)
+      current: this.activeRevision(keyPrefix)
     }).then(function(results) {
         return results.revisions.map(function(revision) {
           return {
@@ -73,6 +73,11 @@ module.exports = CoreObject.extend({
           };
         });
       });
+  },
+
+  activeRevision: function(keyPrefix) {
+    var currentKey = keyPrefix + ':current';
+    return this._client.get(currentKey);
   },
 
   _listRevisions: function(keyPrefix) {
@@ -115,18 +120,13 @@ module.exports = CoreObject.extend({
     return client.zadd(listKey, score, revisionKey);
   },
 
-  _activeRevision: function(keyPrefix) {
-    var currentKey = keyPrefix + ':current';
-    return this._client.get(currentKey);
-  },
-
   _trimRecentUploadsList: function(keyPrefix, maxEntries) {
     var client = this._client;
     var listKey = keyPrefix + ':revisions';
 
     return Promise.hash({
       revisionsToBeRemoved: client.zrange(listKey, 0, -(maxEntries + 1)),
-      current: this._activeRevision(keyPrefix)
+      current: this.activeRevision(keyPrefix)
     }).then(function(results) {
       var revisions = results.revisionsToBeRemoved;
       var current = results.current;

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -171,6 +171,21 @@ describe('redis', function() {
     });
   });
 
+  describe('#willActivate', function() {
+    it('sets the previous revision to the current revision', function() {
+      var currentRevision = 'q';
+
+      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+        get: function() {
+          return currentRevision;
+        }
+      })));
+
+      var result = redis.activeRevision('key-prefix');
+      assert.equal(result, 'q');
+    });
+  }),
+
   describe('#activate', function() {
     it('rejects if the revisionKey doesn\'t exist in list of uploaded revisions', function() {
       var redis = new Redis({}, new FakeRedis(FakeClient.extend({


### PR DESCRIPTION
ref. https://github.com/ember-cli/ember-cli-deploy/issues/309
Added a tests, it passes, but have not tried with an actual app - as I'm not using redis personally.