### PR TITLE
Use 'activationSuffix' in order to know the active version

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,11 +80,12 @@ module.exports = {
         var filePattern       = this.readConfig('filePattern');
         var keyPrefix         = this.readConfig('keyPrefix');
         var maxRecentUploads  = this.readConfig('maxRecentUploads');
+        var activationSuffix  = this.readConfig('activationSuffix');
         var filePath          = path.join(distDir, filePattern);
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
         return this._readFileContents(filePath)
-          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, revisionKey, this.readConfig('revisionData')))
+          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, revisionKey, this.readConfig('revisionData'), activationSuffix))
           .then(this._uploadSuccessMessage.bind(this))
           .then(function(key) {
             return { redisKey: key };

--- a/index.js
+++ b/index.js
@@ -50,9 +50,10 @@ module.exports = {
           return context.commandOptions.revision || (context.revisionData && context.revisionData.revisionKey);
         },
         redisDeployClient: function(context) {
+          var redisLib = context._redisLib;
           var redisOptions = this.pluginConfig;
           redisOptions.port = this.readConfig('port');
-          var redisLib = context._redisLib;
+          redisOptions.activationSuffix = this.readConfig('activationSuffix');
 
           return new Redis(redisOptions, redisLib);
         },
@@ -80,12 +81,11 @@ module.exports = {
         var filePattern       = this.readConfig('filePattern');
         var keyPrefix         = this.readConfig('keyPrefix');
         var maxRecentUploads  = this.readConfig('maxRecentUploads');
-        var activationSuffix  = this.readConfig('activationSuffix');
         var filePath          = path.join(distDir, filePattern);
 
         this.log('Uploading `' + filePath + '`', { verbose: true });
         return this._readFileContents(filePath)
-          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, revisionKey, this.readConfig('revisionData'), activationSuffix))
+          .then(redisDeployClient.upload.bind(redisDeployClient, keyPrefix, revisionKey, this.readConfig('revisionData')))
           .then(this._uploadSuccessMessage.bind(this))
           .then(function(key) {
             return { redisKey: key };

--- a/index.js
+++ b/index.js
@@ -136,10 +136,9 @@ module.exports = {
       fetchInitialRevisions: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
-        var activationSuffix = this.readConfig('activationSuffix');
         
         this.log('Listing initial revisions for key: `' + keyPrefix + '`', { verbose: true });
-        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix, activationSuffix))
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
           .then(function(revisions) {
             return {
               initialRevisions: revisions
@@ -151,10 +150,9 @@ module.exports = {
       fetchRevisions: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
-        var activationSuffix = this.readConfig('activationSuffix');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix, activationSuffix))
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
           .then(function(revisions) {
             return {
               revisions: revisions

--- a/index.js
+++ b/index.js
@@ -135,8 +135,10 @@ module.exports = {
       fetchInitialRevisions: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var activationSuffix = this.readConfig('activationSuffix');
+        
         this.log('Listing initial revisions for key: `' + keyPrefix + '`', { verbose: true });
-        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix, activationSuffix))
           .then(function(revisions) {
             return {
               initialRevisions: revisions
@@ -148,9 +150,10 @@ module.exports = {
       fetchRevisions: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
+        var activationSuffix = this.readConfig('activationSuffix');
 
         this.log('Listing revisions for key: `' + keyPrefix + '`');
-        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
+        return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix, activationSuffix))
           .then(function(revisions) {
             return {
               revisions: revisions

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -41,8 +41,8 @@ module.exports = CoreObject.extend({
     var value       = args.pop();
     var revisionKey = args[0] || 'default';
     var revisionData = args[1];
+    var activationSuffix = args[2];
     var redisKey    = keyPrefix + ':' + revisionKey;
-
     var maxEntries = this._maxRecentUploads;
     var _this = this;
 
@@ -56,7 +56,7 @@ module.exports = CoreObject.extend({
         }
       })
       .then(this._updateRecentUploadsList.bind(this, keyPrefix, revisionKey))
-      .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries))
+      .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries, activationSuffix))
       .then(function() {
         return redisKey;
       });
@@ -191,13 +191,13 @@ module.exports = CoreObject.extend({
     return client.zadd(listKey, score, revisionKey);
   },
 
-  _trimRecentUploadsList: function(keyPrefix, maxEntries) {
+  _trimRecentUploadsList: function(keyPrefix, maxEntries, activationSuffix) {
     var client = this._client;
     var listKey = keyPrefix + ':revisions';
 
     return Promise.hash({
       revisionsToBeRemoved: client.zrange(listKey, 0, -(maxEntries + 1)),
-      current: this.activeRevision(keyPrefix)
+      current: this.activeRevision(keyPrefix, activationSuffix)
     }).then(function(results) {
       var revisions = results.revisionsToBeRemoved;
       var current = results.current;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -69,12 +69,12 @@ module.exports = CoreObject.extend({
       .then(this._activateRevision.bind(this, keyPrefix, revisionKey, activationSuffix, activeContentSuffix));
   },
 
-  fetchRevisions: function(keyPrefix) {
+  fetchRevisions: function(keyPrefix, activationSuffix) {
     var _this = this;
     return this._listRevisions(keyPrefix).then(function(revisions) {
       return Promise.hash({
         revisions: Promise.resolve(revisions),
-        current: _this.activeRevision(keyPrefix),
+        current: _this.activeRevision(keyPrefix, activationSuffix),
         revisionData: _this._revisionData(keyPrefix, revisions)
       });
     }).then(function(results) {
@@ -91,8 +91,9 @@ module.exports = CoreObject.extend({
     });
   },
 
-  activeRevision: function(keyPrefix) {
-    var currentKey = keyPrefix + ':current';
+  activeRevision: function(keyPrefix, activationSuffix) {
+    activationSuffix = activationSuffix || 'current';
+    var currentKey = keyPrefix + ':' + activationSuffix;
     return this._client.get(currentKey);
   },
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -32,6 +32,7 @@ module.exports = CoreObject.extend({
 
     this._maxRecentUploads = options.maxRecentUploads;
     this._allowOverwrite   = options.allowOverwrite;
+    this._activationSuffix = options.activationSuffix || 'current';
   },
 
   upload: function(/*keyPrefix, revisionKey, value*/) {
@@ -41,7 +42,6 @@ module.exports = CoreObject.extend({
     var value       = args.pop();
     var revisionKey = args[0] || 'default';
     var revisionData = args[1];
-    var activationSuffix = args[2];
     var redisKey    = keyPrefix + ':' + revisionKey;
     var maxEntries = this._maxRecentUploads;
     var _this = this;
@@ -56,7 +56,7 @@ module.exports = CoreObject.extend({
         }
       })
       .then(this._updateRecentUploadsList.bind(this, keyPrefix, revisionKey))
-      .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries, activationSuffix))
+      .then(this._trimRecentUploadsList.bind(this, keyPrefix, maxEntries))
       .then(function() {
         return redisKey;
       });
@@ -69,12 +69,12 @@ module.exports = CoreObject.extend({
       .then(this._activateRevision.bind(this, keyPrefix, revisionKey, activationSuffix, activeContentSuffix));
   },
 
-  fetchRevisions: function(keyPrefix, activationSuffix) {
+  fetchRevisions: function(keyPrefix) {
     var _this = this;
     return this._listRevisions(keyPrefix).then(function(revisions) {
       return Promise.hash({
         revisions: Promise.resolve(revisions),
-        current: _this.activeRevision(keyPrefix, activationSuffix),
+        current: _this.activeRevision(keyPrefix),
         revisionData: _this._revisionData(keyPrefix, revisions)
       });
     }).then(function(results) {
@@ -91,9 +91,8 @@ module.exports = CoreObject.extend({
     });
   },
 
-  activeRevision: function(keyPrefix, activationSuffix) {
-    activationSuffix = activationSuffix || 'current';
-    var currentKey = keyPrefix + ':' + activationSuffix;
+  activeRevision: function(keyPrefix) {
+    var currentKey = keyPrefix + ':' + this._activationSuffix;
     return this._client.get(currentKey);
   },
 
@@ -191,13 +190,13 @@ module.exports = CoreObject.extend({
     return client.zadd(listKey, score, revisionKey);
   },
 
-  _trimRecentUploadsList: function(keyPrefix, maxEntries, activationSuffix) {
+  _trimRecentUploadsList: function(keyPrefix, maxEntries) {
     var client = this._client;
     var listKey = keyPrefix + ':revisions';
 
     return Promise.hash({
       revisionsToBeRemoved: client.zrange(listKey, 0, -(maxEntries + 1)),
-      current: this.activeRevision(keyPrefix, activationSuffix)
+      current: this.activeRevision(keyPrefix)
     }).then(function(results) {
       var revisions = results.revisionsToBeRemoved;
       var current = results.current;

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -376,13 +376,15 @@ describe('redis', function() {
     });
 
     it('uses activationSuffix in order to get the right activeRevision', function() {
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+      var redis = new Redis({
+        activationSuffix: 'active-key'
+      }, new FakeRedis(FakeClient.extend({
         get: function(key) {
           return Promise.resolve(key);
         }
       })));
 
-      var promise = redis.activeRevision('key-prefix', 'active-key');
+      var promise = redis.activeRevision('key-prefix');
       return assert.isFulfilled(promise)
         .then(function(result) {
           assert.equal(result, 'key-prefix:active-key');

--- a/tests/unit/lib/redis-nodetest.js
+++ b/tests/unit/lib/redis-nodetest.js
@@ -374,5 +374,19 @@ describe('redis', function() {
           ]);
         });
     });
+
+    it('uses activationSuffix in order to get the right activeRevision', function() {
+      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+        get: function(key) {
+          return Promise.resolve(key);
+        }
+      })));
+
+      var promise = redis.activeRevision('key-prefix', 'active-key');
+      return assert.isFulfilled(promise)
+        .then(function(result) {
+          assert.equal(result, 'key-prefix:active-key');
+        });
+    });
   });
 });


### PR DESCRIPTION
## What Changed & Why
Appended the **activationSuffix** to the key used to know the active version. Right now the issue happen when you change the **activationSuffix** in your redis config, later when you list the uploads `ember deploy:list staging` the output table doesn't point to the right one because the **activeRevision** method has hardcoded **:current**.

## Related issues

## PR Checklist
- [x] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
@achambers

