### PR TITLE
previousRevisionKey returns an unresolved promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,12 +98,14 @@ module.exports = {
         var keyPrefix         = this.readConfig('keyPrefix');
 
         var revisionKey = redisDeployClient.activeRevision(keyPrefix);
-        
-        return {
-          revisionData: {
-            previousRevisionKey: revisionKey
-          }
-        };
+
+        return Promise.resolve(revisionKey).then(function(previousRevisionKey) {
+          return {
+            revisionData: {
+              previousRevisionKey: previousRevisionKey
+            }
+          };
+        });
       },
 
       activate: function(/* context */) {
@@ -136,7 +138,7 @@ module.exports = {
       fetchInitialRevisions: function(/* context */) {
         var redisDeployClient = this.readConfig('redisDeployClient');
         var keyPrefix = this.readConfig('keyPrefix');
-        
+
         this.log('Listing initial revisions for key: `' + keyPrefix + '`', { verbose: true });
         return Promise.resolve(redisDeployClient.fetchRevisions(keyPrefix))
           .then(function(revisions) {


### PR DESCRIPTION
`context.revisionData.previousRevisionKey` is currently an unresolved Promise – it doesn't get resolved by the ember-cli-deploy hook because it's in a POJO. This resolves the promise before returning the object
