### PR TITLE
Fix readConfig bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,20 @@ module.exports = {
         revisionKey: function(context) {
           return context.commandOptions.revision || (context.revisionData && context.revisionData.revisionKey);
         },
-        redisDeployClient: function(context) {
+        redisDeployClient: function(context, pluginHelper) {
           var redisLib = context._redisLib;
-          var redisOptions = this.pluginConfig;
-          redisOptions.port = this.readConfig('port');
-          redisOptions.activationSuffix = this.readConfig('activationSuffix');
+          var options = {
+            url: pluginHelper.readConfig('url'),
+            host: pluginHelper.readConfig('host'),
+            port: pluginHelper.readConfig('port'),
+            password: pluginHelper.readConfig('password'),
+            database: pluginHelper.readConfig('database'),
+            maxRecentUploads: pluginHelper.readConfig('maxRecentUploads'),
+            allowOverwrite: pluginHelper.readConfig('allowOverwrite'),
+            activationSuffix: pluginHelper.readConfig('activationSuffix')
+          };
 
-          return new Redis(redisOptions, redisLib);
+          return new Redis(options, redisLib);
         },
 
         revisionData: function(context) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -4,7 +4,7 @@ var Promise    = require('ember-cli/lib/ext/promise');
 module.exports = CoreObject.extend({
 
   init: function(options, lib) {
-    var redisOptions = options;
+    var redisOptions = {};
     var redisLib     = lib;
 
     if (options.url) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chalk": "^1.0.0",
     "core-object": "^1.1.0",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-deploy-plugin": "^0.2.1",
+    "ember-cli-deploy-plugin": "^0.2.9",
     "redis": "^0.12.1",
     "rsvp": "^3.0.18",
     "then-redis": "^1.3.0"


### PR DESCRIPTION
Fixes #64 

This PR will use the new `pluginHelper.readConfig` function to access config values of this plugin as `this.readConfig` is no longer a valid function in a config property function.