### PR TITLE
Multi file upload

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -158,6 +158,37 @@ module.exports = CoreObject.extend({
   },
 
   _uploadIfKeyDoesNotExist: function(redisKey, value) {
+    if(Object.keys(value).length === 1) {
+      return this._uploadStringIfKeyDoesNotExist(redisKey, value[Object.keys(value)[0]]);
+    } else {
+      return this._uploadHashIfKeyDoesNotExist(redisKey, value);
+    }
+  },
+
+  _uploadHashIfKeyDoesNotExist: function(redisKey, hsh) {
+    var client         = this._client;
+    var allowOverwrite = !!this._allowOverwrite;
+
+    return RSVP.resolve()
+      .then(function() {
+        return client.hlen(redisKey);
+      })
+      .then(function(value) {
+        if (value > 0 && !allowOverwrite) {
+          return RSVP.reject('Value already exists for key: ' + redisKey);
+        }
+      })
+      .then(function() {
+        var redisArr = Object.keys(hsh).reduce(function(arr, key){
+          arr.push(key);
+          arr.push(hsh[key]);
+          return arr;
+        }, [redisKey]);
+        return client.hmset.apply(client, redisArr);
+      });
+  },
+
+  _uploadStringIfKeyDoesNotExist: function(redisKey, value) {
     var client         = this._client;
     var allowOverwrite = !!this._allowOverwrite;
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "chalk": "^1.1.3",
     "core-object": "^2.0.6",
     "ember-cli-deploy-plugin": "^0.2.9",
+    "glob": "^7.1.2",
+    "minimatch": "^3.0.3",
     "redis": "^2.6.3",
     "rsvp": "^3.0.18",
     "then-redis": "^2.0.1"

--- a/tests/helpers/fake-redis-client.js
+++ b/tests/helpers/fake-redis-client.js
@@ -11,6 +11,10 @@ module.exports = CoreObject.extend({
     return RSVP.resolve('some-other-value');
   },
   set: function() { },
+  hlen: function(/* key */) {
+    return RSVP.resolve(0);
+  },
+  hmset: function() { },
   del: function() { },
   zadd: function(key, score , tag) {
     var prefix = key.replace(':revisions','');

--- a/tests/unit/lib/redis-test.js
+++ b/tests/unit/lib/redis-test.js
@@ -16,10 +16,31 @@ describe('redis', function() {
   });
 
   describe('#upload', function() {
+    describe('multiple files', function() {
+      it('uploads the contents if the key does not already exist', function() {
+        var fileUploaded = false;
+
+        var redis = new Redis({}, new FakeRedis(FakeClient.extend({
+          hlen: function(key) {
+            return RSVP.resolve(0);
+          },
+          hmset: function(key) {
+            fileUploaded = true;
+          }
+       })));
+
+        var promise = redis.upload('key', {'index.html': 'value', 'vendor.js': "'use strict';"});
+        return assert.isFulfilled(promise)
+          .then(function() {
+            assert.ok(fileUploaded);
+          });
+      });
+    });
+
     it('rejects if the key already exists in redis', function() {
       var redis = new Redis({}, new FakeRedis());
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', {'index.html': 'value'});
       return assert.isRejected(promise, /^Value already exists for key: key:default$/);
     });
 
@@ -41,7 +62,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', {'index.html': 'value'});
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok(fileUploaded);
@@ -59,7 +80,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', {'index.html': 'value'});
       return assert.isFulfilled(promise)
         .then(function() {
           assert.ok(fileUploaded);
@@ -73,7 +94,7 @@ describe('redis', function() {
         }
       })));
 
-      var promise = redis.upload('key', 'value');
+      var promise = redis.upload('key', {'index.html': 'value'});
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 1);
@@ -102,7 +123,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
 
-      var promise = redis.upload('key', '12', 'value');
+      var promise = redis.upload('key', '12', {'index.html': 'value'});
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 10);
@@ -127,7 +148,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
 
-      var promise = redis.upload('key', '12', 'value');
+      var promise = redis.upload('key', '12', {'index.html': 'value'});
       return assert.isFulfilled(promise)
         .then(function() {
           assert.equal(redis._client.recentRevisions.length, 11);
@@ -150,7 +171,7 @@ describe('redis', function() {
 
       redis._client.recentRevisions = ['1','2','3','4','5'];
 
-      var promise = redis.upload('key', '6', 'value');
+      var promise = redis.upload('key', '6', {'index.html': 'value'});
       return assert.isFulfilled(promise)
           .then(function() {
             assert.equal(redis._client.recentRevisions.length, 5);
@@ -169,7 +190,7 @@ describe('redis', function() {
           }
         })));
 
-        var promise = redis.upload('key', 'value');
+        var promise = redis.upload('key', {'index.html': 'value'});
         return assert.isRejected(promise)
           .then(function() {
             assert.equal(redisKey, 'key:default');
@@ -185,7 +206,7 @@ describe('redis', function() {
             }
         })));
 
-        var promise = redis.upload('key', 'tag', 'value');
+        var promise = redis.upload('key', 'tag', {'index.html': 'value'});
         return assert.isRejected(promise)
           .then(function() {
             assert.equal(redisKey, 'key:tag');

--- a/yarn.lock
+++ b/yarn.lock
@@ -413,6 +413,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -503,6 +507,13 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -3389,6 +3400,12 @@ minimatch@^2.0.1, minimatch@^2.0.3:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
     brace-expansion "^1.0.0"
+
+minimatch@^3.0.3:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
 
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"


### PR DESCRIPTION
## What Changed & Why
Support multiple file upload that are matched using filePattern.
Backwards compatible, default is old behavior using single index.html file.
Multiple files stored in redis hash using `HMSET`

## Related issues
#55 

## PR Checklist
- [x] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
@YoranBrondsema 
