### PR TITLE
Better Error Message for Bad Redis URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,6 +74,12 @@ module.exports = {
 
         if (!this.pluginConfig.url) {
           ['host', 'port'].forEach(this.applyDefaultConfigProperty.bind(this));
+        } else {
+          var redisUrlRegexp = new RegExp('^redis://');
+
+          if (!this.pluginConfig.url.match(redisUrlRegexp)) {
+            throw new Error('Your Redis URL appears to be missing the "redis://" protocol. Update your URL to: redis://' + this.pluginConfig.url);
+          }
         }
 
         ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'activeContentSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient', 'maxRecentUploads', 'revisionData'].forEach(this.applyDefaultConfigProperty.bind(this));

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -143,6 +143,31 @@ describe('redis plugin', function() {
 
         assert.equal(redisLib.createdClient.options, 'redis://:password@host.amazonaws.com:6379/4');
       });
+
+      it('throws if the Redis URL is missing the "redis://" protocol', function() {
+        var plugin = subject.createDeployPlugin({
+          name: 'redis'
+        });
+
+        var redisLib = new FakeRedis();
+
+        var context = {
+          ui: mockUi,
+          project: stubProject,
+          config: {
+            redis: {
+              url: 'host.amazonaws.com:6379/4'
+            }
+          },
+          _redisLib: redisLib
+        };
+
+        plugin.beforeHook(context);
+
+        assert.throws(function() {
+          plugin.configure(context);
+        }, 'Your Redis URL appears to be missing the "redis://" protocol. Update your URL to: redis://host.amazonaws.com:6379/4');
+      });
     });
 
     describe('resolving port from the pipeline', function() {


### PR DESCRIPTION
## What Changed & Why

In the past a Redis URL missing the redis:// protocol would result in an
experience like this:

```
cleaning up...
Deploying [==>------] 33% [plugin: redis ->
fetchInitialRevisions]events.js:183
throw er; // Unhandled 'error' event
            ^

Error: Redis connection to 127.0.0.1:6379 failed - connect
ECONNREFUSED 127.0.0.1:6379
  at Object._errnoException (util.js:1022:11)
  at _exceptionWithHostPort (util.js:1044:20)
  at TCPConnectWrap.afterConnect [as oncomplete]
    (net.js:1182:14)
```

This experience doesn't provide a helpful error message. Going forward
the experience would be:

```
Your Redis URL appears to be missing the "redis://" protocol. Update your URL to: redis://host.amazonaws.com:6379/4
```

This would happen even before we attempt to connect to Redis.

## Related issues

Resolves #82