### PR TITLE
Replace then-redis with ioredis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-  - 4
-  - 6
+  - '4'
+  - '6'
+  - '8'
+  - '10'
 sudo: false
 cache:
   yarn: true

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -6,7 +6,7 @@ module.exports = CoreObject.extend({
   init: function(options, lib) {
     this._super();
     var redisOptions = {};
-    var redisLib     = lib;
+    var RedisLib     = lib;
 
     if (options.url) {
       redisOptions = this._stripUsernameFromConfigUrl(options.url);
@@ -21,15 +21,15 @@ module.exports = CoreObject.extend({
       }
 
       if (options.database) {
-        redisOptions.database = options.database;
+        redisOptions.db = options.database;
       }
     }
 
-    if (!redisLib) {
-      redisLib = require('then-redis');
+    if (!RedisLib) {
+      RedisLib = require('ioredis');
     }
 
-    this._client = redisLib.createClient(redisOptions);
+    this._client = new RedisLib(redisOptions);
 
     this._maxRecentUploads = options.maxRecentUploads;
     this._allowOverwrite = options.allowOverwrite;
@@ -204,13 +204,16 @@ module.exports = CoreObject.extend({
       if (!revisions) {
         return;
       }
+      var promises = [];
       revisions.forEach(function(revision) {
         if (revision !== current) {
-          client.del(keyPrefix + ":" + revision);
-          client.del(keyPrefix + ":revision-data:" + revision);
-          client.zrem(listKey, revision);
+          promises.push(client.del(keyPrefix + ":" + revision));
+          promises.push(client.del(keyPrefix + ":revision-data:" + revision));
+          promises.push(client.zrem(listKey, revision));
         }
       });
+
+      return RSVP.all(promises);
     });
   },
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "eslint": "^3.18.0",
     "github": "^6.1.0",
     "glob": "^7.1.1",
+    "ioredis-mock": "^3.14.0",
     "mocha": "^3.2.0",
-    "multiline": "^1.0.2"
+    "multiline": "^1.0.2",
+    "sinon": "^6.1.5"
   },
   "keywords": [
     "ember-addon",
@@ -34,9 +36,9 @@
     "chalk": "^1.1.3",
     "core-object": "^2.0.6",
     "ember-cli-deploy-plugin": "^0.2.9",
+    "ioredis": "^3.2.2",
     "redis": "^2.6.3",
-    "rsvp": "^3.0.18",
-    "then-redis": "^2.0.1"
+    "rsvp": "^3.0.18"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/unit/lib/redis-test.js
+++ b/tests/unit/lib/redis-test.js
@@ -1,391 +1,353 @@
 'use strict';
 
-var FakeRedis = require('../../helpers/fake-redis-lib');
-var FakeClient = require('../../helpers/fake-redis-client');
-
+var IoredisMock = require('ioredis-mock');
 
 var RSVP = require('rsvp');
-var assert  = require('../../helpers/assert');
-var CoreObject = require('core-object');
+var assert = require('../../helpers/assert');
+var sandbox = require('sinon').createSandbox();
 
-describe('redis', function() {
+describe('redis', function () {
   var Redis;
 
-  before(function() {
+  before(function () {
     Redis = require('../../../lib/redis');
   });
 
-  describe('#upload', function() {
-    it('rejects if the key already exists in redis', function() {
-      var redis = new Redis({}, new FakeRedis());
+  afterEach(function () {
+    sandbox.restore();
+  });
 
-      var promise = redis.upload('key', 'value');
-      return assert.isRejected(promise, /^Value already exists for key: key:default$/);
+  describe('#upload', function () {
+    it('rejects if the key already exists in redis', function () {
+      var redis = new Redis({}, IoredisMock);
+
+      return redis.upload('key', 'value').then(() => {
+        var promise = redis.upload('key', 'value');
+        assert.isRejected(promise, /^Value already exists for key: key:default$/);
+      });
     });
 
-    it('uploads the contents if the key does not already exist', function() {
-      var fileUploaded = false;
+    it('uploads the contents if the key does not already exist', function () {
+      var redis = new Redis({}, IoredisMock);
 
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function(key) {
-          return RSVP.resolve(null);
-        },
-        set: function(key, value) {
-          fileUploaded = true;
-        },
-        zadd: function(key, value) {
-          assert(key.match(/:revisions$/));
-        },
-        zrange: function(key, value) {
-          assert(key.match(/:revisions$/));
-        }
-      })));
-
-      var promise = redis.upload('key', 'value');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.ok(fileUploaded);
-        });
+      var promise = redis.upload('key', 'value', 'filecontents');
+      return assert.isFulfilled(promise).then(() => {
+        return redis._client.get('key:value');
+      }).then((value) => {
+        assert.equal(value, 'filecontents');
+      });
     });
 
-    it('uploads the contents if the key already exists but allowOverwrite is true', function() {
-      var fileUploaded = false;
-
+    it('uploads the contents if the key already exists but allowOverwrite is true', function () {
       var redis = new Redis({
         allowOverwrite: true
-      }, new FakeRedis(FakeClient.extend({
-        set: function(key, value) {
-          fileUploaded = true;
-        }
-      })));
+      }, IoredisMock);
 
-      var promise = redis.upload('key', 'value');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.ok(fileUploaded);
+      return redis.upload('key', 'value', 'firstfilecontents').then(() => {
+        return redis.upload('key', 'value', 'secondfilecontents');
+      }).then(() => {
+        return redis._client.get('key:value');
+      }).then((value) => {
+        assert.equal(value, 'secondfilecontents');
+      });
+    });
+
+    it('trims the list of recent uploads and removes the index key and the revisionData', function () {
+      var redis = new Redis({
+        maxRecentUploads: 2
+      }, IoredisMock);
+
+      return RSVP.resolve()
+        .then(() => {
+          return redis.upload('key', 1, '1value');
+        })
+        .then(() => {
+          return redis.upload('key', 2, '2value');
+        })
+        .then(() => {
+          return redis.upload('key', 3, '3value');
+        })
+        .then(() => {
+          return redis._client.mget('key:1', 'key:revision-data:1')
+        })
+        .then((values) => {
+          assert.equal(values.filter(Boolean).length, 0, 'Expected key:1 and key:revision-data:1 to be deleted.');
+          return redis._client.zrange('key:revisions', 0, -1);
+        })
+        .then((value) => {
+          assert.deepEqual(value, ['2', '3']);
         });
     });
 
-    it('updates the list of recent uploads once upload is successful', function() {
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function(key) {
-          return RSVP.resolve(null);
-        }
-      })));
+    it('trims the list of recent uploads but leaves the active one', function () {
+      var redis = new Redis({
+        maxRecentUploads: 2
+      }, IoredisMock);
 
-      var promise = redis.upload('key', 'value');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.equal(redis._client.recentRevisions.length, 1);
-          assert.equal(redis._client.recentRevisions[0], 'key:default');
+      return RSVP.resolve()
+        .then(() => {
+          return redis.upload('key', 1, '1value');
+        })
+        .then(() => {
+          return redis._client.set('key:current', '1');
+        })
+        .then(() => {
+          return redis.upload('key', 2, '2value');
+        })
+        .then(() => {
+          return redis.upload('key', 3, '3value');
+        })
+        .then(() => {
+          return redis.upload('key', 4, '4value');
+        })
+        .then(() => {
+          return redis._client.keys('*');
+        })
+        .then((values) => {
+          assert.deepEqual(values, [
+            'key:1',
+            'key:revisions',
+            'key:current',
+            'key:3', // key 2 was trimmed
+            'key:4'
+          ]);
         });
     });
 
-    it('trims the list of recent uploads and removes the index key and the revisionData', function() {
-      var finalUploads = ['3','4','5','6','7','8','9','10','11','key:12'];
+    describe('generating the redis key', function () {
+      it('will use just the default tag if the tag is not provided', function () {
+        var redis = new Redis({}, IoredisMock);
 
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function(key) {
-          return RSVP.resolve(null);
-        },
-        del: function(key) {
-          assert(key === 'key:1' || key === 'key:2' || key === 'key:revision-data:1' || key === 'key:revision-data:2');
-        },
-        zrange: function() {
-          return this.recentRevisions.slice(0,2);
-        },
-        zrem: function(key) {
-          assert(key.match(/:revisions$/));
-          return this._super.apply(this, arguments);
-        }
-      })));
-
-      redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
-
-      var promise = redis.upload('key', '12', 'value');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.equal(redis._client.recentRevisions.length, 10);
-          assert.deepEqual(redis._client.recentRevisions, finalUploads);
-        });
-    });
-
-    it('trims the list of recent uploads but leaves the active one', function() {
-      var finalUploads = ['1','3','4','5','6','7','8','9','10','11','key:12'];
-
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function(key) {
-          if (key == 'key:current') {
-            return RSVP.resolve('1');
-          }
-          return RSVP.resolve(null);
-        },
-        zrange: function() {
-          return this.recentRevisions.slice(0,2);
-        }
-      })));
-
-      redis._client.recentRevisions = ['1','2','3','4','5','6','7','8','9','10','11'];
-
-      var promise = redis.upload('key', '12', 'value');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.equal(redis._client.recentRevisions.length, 11);
-          assert.deepEqual(redis._client.recentRevisions, finalUploads);
-        });
-    });
-
-    it('trims the list of recent uploads if maxRecentUploads exists', function() {
-      var finalUploads = ['2','3','4','5','key:6'];
-
-      var redis = new Redis({ maxRecentUploads: 5 }, new FakeRedis(FakeClient.extend({
-        get: function(/* key */) {
-          return RSVP.resolve(null);
-        },
-        zrange: function(listKey, startIndex, stopIndex) {
-          var end = this.recentRevisions.length - (Math.abs(stopIndex) - 1);
-          return this.recentRevisions.slice(0, end);
-        }
-      })));
-
-      redis._client.recentRevisions = ['1','2','3','4','5'];
-
-      var promise = redis.upload('key', '6', 'value');
-      return assert.isFulfilled(promise)
-          .then(function() {
-            assert.equal(redis._client.recentRevisions.length, 5);
-            assert.deepEqual(redis._client.recentRevisions, finalUploads);
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', undefined, 'filecontents');
+          })
+          .then(() => {
+            return redis._client.get('key:default');
+          })
+          .then((value) => {
+            assert.equal(value, 'filecontents');
           });
-    });
-
-    describe('generating the redis key', function() {
-      it('will use just the default tag if the tag is not provided', function() {
-        var redisKey = null;
-
-        var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-          get: function(key) {
-              redisKey = key;
-              return RSVP.resolve('some-other-value');
-          }
-        })));
-
-        var promise = redis.upload('key', 'value');
-        return assert.isRejected(promise)
-          .then(function() {
-            assert.equal(redisKey, 'key:default');
-          })
       });
 
-      it('will use the key and the tag if the tag is provided', function() {
-        var redisKey = null;
-        var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-          get: function(key) {
-              redisKey = key;
-              return RSVP.resolve('some-other-value');
-            }
-        })));
+      it('will use the key and the tag if the tag is provided', function () {
+        var redis = new Redis({}, IoredisMock);
 
-        var promise = redis.upload('key', 'tag', 'value');
-        return assert.isRejected(promise)
-          .then(function() {
-            assert.equal(redisKey, 'key:tag');
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', 'tag', 'filecontents');
           })
+          .then(() => {
+            return redis._client.get('key:tag');
+          })
+          .then((value) => {
+            assert.equal(value, 'filecontents');
+          });
       });
     });
   });
 
-  describe('#willActivate', function() {
-    it('sets the previous revision to the current revision', function() {
-      var currentRevision = 'q';
+  describe('#willActivate', function () {
+      it('sets the previous revision to the current revision', function () {
+        var redis = new Redis({}, IoredisMock);
 
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function() {
-          return currentRevision;
-        }
-      })));
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', '1', 'filecontents1');
+          })
+          .then(() => {
+            return redis.upload('key', '2', 'filecontents2');
+          })
+          .then(() => {
+            return redis.activate('key', '1', 'current');
+          })
+          .then(() => {
+            return redis.activeRevision('key');
+          })
+          .then((activeRevision) => {
+            assert.equal(activeRevision, '1');
+          });
+      });
+    }),
 
-      var result = redis.activeRevision('key-prefix');
-      assert.equal(result, 'q');
-    });
-  }),
+    describe('#activate', function () {
+      it('rejects if the revisionKey doesn\'t exist in list of uploaded revisions', function () {
+        var redis = new Redis({}, IoredisMock);
 
-  describe('#activate', function() {
-    it('rejects if the revisionKey doesn\'t exist in list of uploaded revisions', function() {
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        zrevrange: function() {
-          return this.recentRevisions;
-        }
-      })));
-
-      redis._client.recentRevisions = ['a', 'b', 'c'];
-
-      var promise = redis.activate('key-prefix', 'revision-key');
-      return assert.isRejected(promise)
-        .then(function(error) {
-          assert.equal(error, '`revision-key` is not a valid revision key');
-        });
-    });
-
-    it('resolves and sets the current revision to the revision key provided', function() {
-      var redisKey, redisValue;
-
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        set: function(key, value) {
-          redisKey = key;
-          redisValue = value;
-        }
-      })));
-
-      redis._client.recentRevisions = ['a', 'b', 'c'];
-
-      var promise = redis.activate('key-prefix', 'c', 'current');
-      return assert.isFulfilled(promise)
-        .then(function() {
-          assert.equal(redisKey, 'key-prefix:current');
-          assert.equal(redisValue, 'c');
-        });
-    });
-
-    it('copies revision to the activeContentSuffix', function() {
-      var redisKey, redisValue;
-
-      var redisClient = new FakeRedis(FakeClient.extend({
-        _db: {
-          "key-prefix:a": "first revision content",
-          "key-prefix:b": "second revision content",
-          "key-prefix:c": "third revision content"
-        },
-
-        get: function(key) {
-          return RSVP.resolve(this._db[key]);
-        },
-        set: function(key, value) {
-          this._db[key] = value;
-          return RSVP.resolve(value);
-        },
-      }));
-
-      var redis = new Redis({}, redisClient);
-
-      redis._client.recentRevisions = ['a', 'b', 'c'];
-
-      var activate = redis.activate('key-prefix', 'c', 'current-id', 'current-content').then(function() {
-        return redis._client.get('key-prefix:current-content');
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', '1', 'filecontents1');
+          })
+          .then(() => {
+            return redis.upload('key', '2', 'filecontents2');
+          })
+          .then(() => {
+            var promise = redis.activate('key', '3', 'current');
+            return assert.isRejected(promise);
+          })
       });
 
-      return assert.isFulfilled(activate)
-        .then(function(result) {
-          assert.equal(result, "third revision content");
-        });
-    });
-  });
+      it('resolves and sets the current revision to the revision key provided', function () {
+        var redis = new Redis({}, IoredisMock);
 
-  describe('#fetchRevisions', function() {
-    it('lists the last existing revisions', function() {
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-      })));
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', '1', 'filecontents1');
+          })
+          .then(() => {
+            return redis.upload('key', '2', 'filecontents2');
+          })
+          .then(() => {
+            return redis.activate('key', '1', 'current');
+          })
+          .then(() => {
+            return redis.activeRevision('key');
+          })
+          .then((activeRevision) => {
+            assert.equal(activeRevision, '1');
+            return redis._client.get('key:1');
+          }).then((keyContents) => {
+            assert.equal(keyContents, 'filecontents1');
+          });
+      });
 
-      redis._client.recentRevisions = ['a', 'b', 'c'];
+      it('copies revision to the activeContentSuffix', function () {
+        var redis = new Redis({}, IoredisMock);
 
-      var promise = redis.fetchRevisions('key-prefix');
-      return assert.isFulfilled(promise)
-        .then(function(result) {
-          assert.deepEqual(result, [
-            {
-              revision: 'a',
-              active: false
-            },
-            {
-              revision: 'b',
-              active: false
-            },
-            {
-              revision: 'c',
-              active: false
-            }
-          ]
-        );
+        return RSVP.resolve()
+          .then(() => {
+            return redis.upload('key', '1', 'filecontents1');
+          })
+          .then(() => {
+            return redis.upload('key', '2', 'filecontents2');
+          })
+          .then(() => {
+            return redis.upload('key', '3', 'filecontents3');
+          })
+          .then(() => {
+            return redis.activate('key', '1', 'current-id', 'current-content');
+          })
+          .then(() => {
+            return redis._client.get('key:current-content');
+          })
+          .then((currentContent) => {
+            assert.equal(currentContent, 'filecontents1');
+            return redis._client.get('key:current-id');
+          }).then((currentId) => {
+            assert.equal(currentId, '1');
+          });
       });
     });
 
-    it('lists revisions and marks the active one', function() {
-      var currentRevision = 'b';
+  describe('#fetchRevisions', function () {
+    it('lists the last existing revisions', function () {
+      var redis = new Redis({}, IoredisMock);
 
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function() {
-          return currentRevision;
-        },
-        zrevrange: function(key) {
-          assert(key.match(/:revisions$/));
-          return this._super.apply(this, arguments);
-        }
-      })));
-
-      redis._client.recentRevisions = ['a', 'b'];
-
-      var promise = redis.fetchRevisions('key-prefix');
-      return assert.isFulfilled(promise)
-        .then(function(result) {
-          assert.deepEqual(result, [
-            {
-              revision: 'a',
-              active: false
-            },
-            {
-              revision: 'b',
-              active: true
-            }
-          ]
-        );
-      });
-    });
-
-    it('retrieves revisionData', function() {
-      var redis = new Redis({}, new FakeRedis(FakeClient.extend({
-        get: function() {
-        },
-        mget: function(keys) {
-          return RSVP.resolve(['{"revisionKey":"a","timestamp":"2016-03-13T14:25:40.563Z","scm":{"sha":"9101968710f18a6720c48bf032fd82efd5743b7d","email":"mattia@mail.com","name":"Mattia Gheda","timestamp":"2015-12-22T12:44:48.000Z","branch":"master"}}']);
-        }
-      })));
-
-      redis._client.recentRevisions = ['a'];
-
-      var promise = redis.fetchRevisions('key-prefix');
-      return assert.isFulfilled(promise)
-        .then(function(result) {
-          assert.deepEqual(result, [
-            {
-              revision: 'a',
+      return RSVP.resolve()
+        .then(() => {
+          return redis.upload('key', '1', 'filecontents1');
+        })
+        .then(() => {
+          return redis.upload('key', '2', 'filecontents2');
+        })
+        .then(() => {
+          return redis.upload('key', '3', 'filecontents3');
+        })
+        .then(() => {
+          return redis.fetchRevisions('key');
+        })
+        .then((recentRevisions) => {
+          assert.deepEqual(recentRevisions, [{
+              revision: '3',
               active: false,
-              revisionData: {
-                revisionKey: 'a',
-                timestamp: '2016-03-13T14:25:40.563Z',
-                scm:
-                { sha: '9101968710f18a6720c48bf032fd82efd5743b7d',
-                  email: 'mattia@mail.com',
-                  name: 'Mattia Gheda',
-                  timestamp: '2015-12-22T12:44:48.000Z',
-                  branch: 'master' }
-              }
+              revisionData: null
+            },
+            {
+              revision: '2',
+              active: false,
+              revisionData: null
+            },
+            {
+              revision: '1',
+              active: false,
+              revisionData: null
             }
           ]);
         });
     });
 
-    it('uses activationSuffix in order to get the right activeRevision', function() {
+    it('lists revisions and marks the active one', function () {
+      var redis = new Redis({}, IoredisMock);
+
+      return RSVP.resolve()
+        .then(() => {
+          return redis.upload('key', '1', 'filecontents1');
+        })
+        .then(() => {
+          return redis.activate('key', '1', 'current');
+        })
+        .then(() => {
+          return redis.upload('key', '2', 'filecontents2');
+        })
+        .then(() => {
+          return redis.upload('key', '3', 'filecontents3');
+        })
+        .then(() => {
+          return redis.fetchRevisions('key');
+        })
+        .then((recentRevisions) => {
+          assert.deepEqual(recentRevisions, [{
+              revision: '3',
+              active: false,
+              revisionData: null
+            },
+            {
+              revision: '2',
+              active: false,
+              revisionData: null
+            },
+            {
+              revision: '1',
+              active: true,
+              revisionData: null
+            }
+          ]);
+        });
+    });
+
+    it('retrieves revisionData', function () {
+      var redis = new Redis({}, IoredisMock);
+      var revisionData = '{"revisionKey":"a","timestamp":"2016-03-13T14:25:40.563Z","scm":{"sha":"9101968710f18a6720c48bf032fd82efd5743b7d","email":"mattia@mail.com","name":"Mattia Gheda","timestamp":"2015-12-22T12:44:48.000Z","branch":"master"}}';
+
+      return RSVP.resolve()
+        .then(() => {
+          return redis.upload('key', '1', revisionData, 'filecontents1');
+        })
+        .then(() => {
+          return redis.fetchRevisions('key');
+        })
+        .then((revisions) => {
+          assert.deepEqual(revisions, [{
+            revision: '1',
+            active: false,
+            revisionData: revisionData
+          }]);
+        });
+    });
+
+    it('uses activationSuffix in order to get the right activeRevision', function () {
       var redis = new Redis({
         activationSuffix: 'active-key'
-      }, new FakeRedis(FakeClient.extend({
-        get: function(key) {
-          return RSVP.resolve(key);
-        }
-      })));
+      }, IoredisMock);
 
-      var promise = redis.activeRevision('key-prefix');
-      return assert.isFulfilled(promise)
-        .then(function(result) {
-          assert.equal(result, 'key-prefix:active-key');
+      var redisGetStub = sandbox.stub(redis._client, 'get').returns(RSVP.Promise.resolve());
+
+      return RSVP.resolve()
+        .then(() => {
+          return redis.activeRevision('key-prefix');
+        })
+        .then(() => {
+          assert.isTrue(redisGetStub.calledWith('key-prefix:active-key'));
         });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@sinonjs/commons@^1.0.1":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.0.2.tgz#3e0ac737781627b8844257fadc3d803997d0526e"
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-2.0.0.tgz#84db7e9eb5531df18a8c5e0bfb6e449e55e654b2"
+  dependencies:
+    samsam "1.3.0"
+
+"@sinonjs/samsam@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-2.0.0.tgz#9163742ac35c12d3602dece74317643b35db6a80"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -165,6 +181,10 @@ array-equal@^1.0.0:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
 
 array-index@^1.0.0:
   version "1.0.0"
@@ -413,6 +433,10 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
 base64-arraybuffer@0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
@@ -469,6 +493,10 @@ bluebird@^3.1.1, bluebird@^3.4.6:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
+bluebird@^3.3.4, bluebird@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 body@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/body/-/body-5.1.0.tgz#e4ba0ce410a46936323367609ecb4e6553125069"
@@ -503,6 +531,13 @@ brace-expansion@^1.0.0:
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.6.tgz#7197d7eaa9b87e648390ea61fc66c84427420df9"
   dependencies:
     balanced-match "^0.4.1"
+    concat-map "0.0.1"
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  dependencies:
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -925,6 +960,10 @@ clone@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
 
+cluster-key-slot@^1.0.6:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz#d5deff2a520717bc98313979b687309b2d368e29"
+
 cmd-shim@~2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cmd-shim/-/cmd-shim-2.0.2.tgz#6fcbda99483a8fd15d7d30a196ca69d688a2efdb"
@@ -1176,6 +1215,12 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
+debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -1239,6 +1284,10 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+denque@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.3.0.tgz#681092ef44a630246d3f6edb2a199230eae8e76b"
+
 depd@1.1.0, depd@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
@@ -1278,6 +1327,10 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
 diff@1.4.0, diff@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
+
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 doctrine@^2.0.0:
   version "2.0.0"
@@ -1642,7 +1695,7 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@^0.1.3:
+es6-map@^0.1.3, es6-map@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
   dependencies:
@@ -1653,7 +1706,7 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-set@~0.1.5:
+es6-set@^0.1.5, es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
   dependencies:
@@ -2026,6 +2079,10 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flexbuffer@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/flexbuffer/-/flexbuffer-0.0.6.tgz#039fdf23f8823e440c38f3277e6fef1174215b30"
 
 follow-redirects@0.0.7:
   version "0.0.7"
@@ -2405,6 +2462,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0, has-unicode@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2614,6 +2675,46 @@ interpret@^1.0.0:
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+
+ioredis-mock@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/ioredis-mock/-/ioredis-mock-3.14.0.tgz#89d01e94aa2d5e30b717d7938b358b689e68e6e3"
+  dependencies:
+    array-from "^2.1.1"
+    bluebird "^3.5.1"
+    es6-map "^0.1.5"
+    es6-set "^0.1.5"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+    object-assign "^4.1.1"
+
+ioredis@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-3.2.2.tgz#b7d5ff3afd77bb9718bb2821329b894b9a44c00b"
+  dependencies:
+    bluebird "^3.3.4"
+    cluster-key-slot "^1.0.6"
+    debug "^2.6.9"
+    denque "^1.1.0"
+    flexbuffer "0.0.6"
+    lodash.assign "^4.2.0"
+    lodash.bind "^4.2.1"
+    lodash.clone "^4.5.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.defaults "^4.2.0"
+    lodash.difference "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.foreach "^4.5.0"
+    lodash.isempty "^4.4.0"
+    lodash.keys "^4.2.0"
+    lodash.noop "^3.0.1"
+    lodash.partial "^4.2.1"
+    lodash.pick "^4.4.0"
+    lodash.sample "^4.2.1"
+    lodash.shuffle "^4.2.0"
+    lodash.values "^4.3.0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.4.0"
 
 ipaddr.js@1.3.0:
   version "1.3.0"
@@ -2872,6 +2973,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+just-extend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-3.0.0.tgz#cee004031eaabf6406da03a7b84e4fe9d78ef288"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"
@@ -3064,9 +3169,21 @@ lodash.assign@^3.2.0:
     lodash._createassigner "^3.0.0"
     lodash.keys "^3.0.0"
 
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+
 lodash.assignin@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
+lodash.clone@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
 
 lodash.clonedeep@^4.4.1, lodash.clonedeep@^4.5.0:
   version "4.5.0"
@@ -3093,6 +3210,14 @@ lodash.debounce@^3.1.1:
   dependencies:
     lodash._getnative "^3.0.0"
 
+lodash.defaults@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+
 lodash.find@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
@@ -3104,6 +3229,18 @@ lodash.flatten@^3.0.2:
     lodash._baseflatten "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3111,6 +3248,10 @@ lodash.isarguments@^3.0.0:
 lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
+
+lodash.isempty@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
 
 lodash.isplainobject@^3.0.0:
   version "3.2.0"
@@ -3131,6 +3272,10 @@ lodash.keys@^3.0.0:
     lodash._getnative "^3.0.0"
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
+
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
 
 lodash.keysin@^3.0.0:
   version "3.0.8"
@@ -3159,6 +3304,10 @@ lodash.merge@^4.3.0, lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.noop@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-3.0.1.tgz#38188f4d650a3a474258439b96ec45b32617133c"
+
 lodash.omit@^4.1.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
@@ -3181,9 +3330,25 @@ lodash.pairs@^3.0.0:
   dependencies:
     lodash.keys "^3.0.0"
 
+lodash.partial@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.partial/-/lodash.partial-4.2.1.tgz#49f3d8cfdaa3bff8b3a91d127e923245418961d4"
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+
+lodash.sample@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.sample/-/lodash.sample-4.2.1.tgz#5e4291b0c753fa1abeb0aab8fb29df1b66f07f6d"
+
+lodash.shuffle@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
 
 lodash.template@^4.2.5:
   version "4.4.0"
@@ -3227,6 +3392,10 @@ lodash.uniq@~3.2.2:
     lodash._isiterateecall "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.values@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
+
 lodash.without@~3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-3.2.1.tgz#d69614b3512e52294b6abab782e7ca96538ce816"
@@ -3241,6 +3410,14 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
 lodash@^4.0.0, lodash@^4.14.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+lodash@^4.17.4:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+
+lolex@^2.3.2, lolex@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.7.1.tgz#e40a8c4d1f14b536aa03e42a537c7adbaf0c20be"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3390,6 +3567,12 @@ minimatch@^2.0.1, minimatch@^2.0.3:
   dependencies:
     brace-expansion "^1.0.0"
 
+minimatch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -3456,6 +3639,10 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 multiline@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/multiline/-/multiline-1.0.2.tgz#69b1f25ff074d2828904f244ddd06b7d96ef6c93"
@@ -3481,6 +3668,16 @@ natural-compare@^1.4.0:
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+nise@^1.4.2:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.4.4.tgz#b8d9dd35334c99e514b75e46fcc38e358caecdd0"
+  dependencies:
+    "@sinonjs/formatio" "^2.0.0"
+    just-extend "^3.0.0"
+    lolex "^2.3.2"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
 
 node-fetch@^1.3.3:
   version "1.6.3"
@@ -3724,7 +3921,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3919,6 +4116,12 @@ path-posix@^1.0.0:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -4176,6 +4379,10 @@ redis-commands@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.3.1.tgz#81d826f45fa9c8b2011f4cd7a0fe597d241d442b"
 
+redis-parser@^2.4.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+
 redis-parser@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.5.0.tgz#79fc2b1d4a6e4d2870b35368433639271fca2617"
@@ -4366,6 +4573,10 @@ safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
+samsam@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
+
 sane@^1.1.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
@@ -4479,6 +4690,20 @@ simple-fmt@~0.1.0:
 simple-is@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/simple-is/-/simple-is-0.2.0.tgz#2abb75aade39deb5cc815ce10e6191164850baf0"
+
+sinon@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-6.1.5.tgz#41451502d43cd5ffb9d051fbf507952400e81d09"
+  dependencies:
+    "@sinonjs/commons" "^1.0.1"
+    "@sinonjs/formatio" "^2.0.0"
+    "@sinonjs/samsam" "^2.0.0"
+    diff "^3.5.0"
+    lodash.get "^4.4.2"
+    lolex "^2.7.1"
+    nise "^1.4.2"
+    supports-color "^5.4.0"
+    type-detect "^4.0.8"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -4731,6 +4956,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^5.4.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
+
 symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.1.8.tgz#cabe61e0010c1c023c173b25ee5108b37f4b4aa3"
@@ -4804,6 +5035,10 @@ testem@^1.8.1:
     tap-parser "^5.1.0"
     xmldom "^0.1.19"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4811,10 +5046,6 @@ text-table@~0.2.0:
 "textextensions@1 || 2":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.0.1.tgz#be8cf22d65379c151319f88f0335ad8f667abdca"
-
-then-redis@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/then-redis/-/then-redis-2.0.1.tgz#e797f18fff7f3c50bfc2ae95a35db5ad0b0816ff"
 
 through@^2.3.6, through@^2.3.8, through@~2.3.8:
   version "2.3.8"
@@ -4902,6 +5133,10 @@ type-check@~0.3.2:
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
+
+type-detect@4.0.8, type-detect@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-detect@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## What Changed & Why

This PR replaces then-redis with ioredis. [then-redis has been deprecated](https://github.com/mjackson/then-redis#this-package-is-no-longer-maintained-node_redis-now-includes-support-for-promises-in-core-so-this-is-no-longer-needed), so we needed to replace it with something.

I chose ioredis over the `node_redis` package because they require Node 8 or higher for native promise support, or you have to [promisify via Bluebird](https://github.com/NodeRedis/node_redis#promises).

Also note that I've used ioredis < 4 because of their requirement of Node 6 or greater. As ember-cli support drops out for Node 4, we should be able to upgrade to the newer versions.

I've tested this using `yarn link` deploying my Ember 2.16 application and have not had any problems.

## Related issues
Fixes #51
Fixes #74

## PR Checklist
- [x] Add tests
- [x] Add documentation (the API should remain the same, so no docs required)

## People

@ghedamat 
