### PR TITLE
Adds TLS redis configuration support for encryption-at-rest enabled redis instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+/.vscode

--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ The Redis client to be used to upload files to the Redis store. By default this 
 
 A message that will be displayed after the file has been successfully uploaded to Redis. By default this message will only display if the revision for `revisionData.revisionKey` of the deployment context has been activated.
 
-*Default:*
-
 ```javascript
 if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionKey) {
   return "Deployed but did not activate revision " + context.revisionData.revisionKey + ". "
@@ -167,6 +165,12 @@ if (context.revisionData.revisionKey && !context.revisionData.activatedRevisionK
        + "ember deploy:activate " + context.revisionData.revisionKey + " --environment=" + context.deployEnvironment + "\n";
 }
 ```
+
+### tls
+
+An optional tls configuration object for connecting to redis instances with encryption-in-transit enabled. Please see [https://github.com/luin/ioredis#tls-options](https://github.com/luin/ioredis#tls-options) for available options
+
+*Default:* `null`
 
 ### maxRecentUploads
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,7 @@ module.exports = {
             url: pluginHelper.readConfig('url'),
             host: pluginHelper.readConfig('host'),
             port: pluginHelper.readConfig('port'),
+            tls: pluginHelper.readConfig('tls'),
             password: pluginHelper.readConfig('password'),
             database: pluginHelper.readConfig('database'),
             maxRecentUploads: pluginHelper.readConfig('maxRecentUploads'),
@@ -82,7 +83,7 @@ module.exports = {
           }
         }
 
-        ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'activeContentSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient', 'maxRecentUploads', 'revisionData'].forEach(this.applyDefaultConfigProperty.bind(this));
+        ['filePattern', 'distDir', 'keyPrefix', 'activationSuffix', 'activeContentSuffix', 'revisionKey', 'didDeployMessage', 'redisDeployClient', 'maxRecentUploads', 'revisionData','tls'].forEach(this.applyDefaultConfigProperty.bind(this));
 
         this.log('config ok', { verbose: true });
       },

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -23,6 +23,10 @@ module.exports = CoreObject.extend({
       if (options.database) {
         redisOptions.db = options.database;
       }
+
+      if (options.tls) {
+        redisOptions.tls = options.tls
+      }
     }
 
     if (!RedisLib) {

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -253,6 +253,54 @@ describe("redis plugin", function() {
       });
     });
 
+    describe("resolving tls from the pipeline", function() {
+      it("uses the config data if it already exists", function() {
+        var plugin = subject.createDeployPlugin({
+          name: "redis"
+        });
+
+        var config = {
+          host: "somehost",
+          port: 1234,
+          tls: {
+            secure: false
+          }
+        };
+        var context = {
+          ui: mockUi,
+          project: stubProject,
+          config: {
+            redis: config
+          }
+        };
+
+        plugin.beforeHook(context);
+        plugin.configure(context);
+        assert.deepEqual(plugin.readConfig("tls"), { secure: false });
+      });
+
+      it("resolves to undefined if not specified in config", function() {
+        var plugin = subject.createDeployPlugin({
+          name: "redis"
+        });
+
+        var config = {
+          host: "somehost"
+        };
+        var context = {
+          ui: mockUi,
+          project: stubProject,
+          config: {
+            redis: config
+          }
+        };
+
+        plugin.beforeHook(context);
+        plugin.configure(context);
+        assert.equal(plugin.readConfig("tls"), undefined);
+      });
+    })
+
     describe("resolving revisionKey from the pipeline", function() {
       it("uses the config data if it already exists", function() {
         var plugin = subject.createDeployPlugin({
@@ -359,7 +407,7 @@ describe("redis plugin", function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 12);
+        assert.equal(messages.length, 13);
       });
       it("adds default config to the config object", function() {
         plugin.configure(context);
@@ -389,7 +437,7 @@ describe("redis plugin", function() {
         };
         plugin.beforeHook(context);
       });
-      it("warns about missing optional filePattern, distDir, activationSuffix, revisionKey, didDeployMessage, maxNumberOfRecentUploads, and connection info", function() {
+      it("warns about missing optional filePattern, distDir, activationSuffix, revisionKey, didDeployMessage, maxNumberOfRecentUploads, and connection info, tls", function() {
         plugin.configure(context);
         var messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
@@ -398,7 +446,7 @@ describe("redis plugin", function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 11);
+        assert.equal(messages.length, 12);
       });
       it("does not add default config to the config object", function() {
         plugin.configure(context);
@@ -429,7 +477,7 @@ describe("redis plugin", function() {
         };
         plugin.beforeHook(context);
       });
-      it("warns about missing optional filePattern, distDir, keyPrefix, revisionKey, didDeployMessage, maxNumberOfRecentUploads, and connection info", function() {
+      it("warns about missing optional filePattern, distDir, keyPrefix, revisionKey, didDeployMessage, maxNumberOfRecentUploads, tls, and connection info", function() {
         plugin.configure(context);
         var messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
@@ -438,7 +486,7 @@ describe("redis plugin", function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 11);
+        assert.equal(messages.length, 12);
       });
       it("does not add default config to the config object", function() {
         plugin.configure(context);
@@ -469,7 +517,7 @@ describe("redis plugin", function() {
         };
         plugin.beforeHook(context);
       });
-      it("warns about missing optional filePattern, distDir, keyPrefix, activationSuffix, revisionKey, maxNumberOfRecentUploads, and didDeployMessage only", function() {
+      it("warns about missing optional filePattern, distDir, keyPrefix, activationSuffix, revisionKey, maxNumberOfRecentUploads, tls, and didDeployMessage only", function() {
         plugin.configure(context);
         var messages = mockUi.messages.reduce(function(previous, current) {
           if (/- Missing config:\s.*, using default:\s/.test(current)) {
@@ -478,7 +526,7 @@ describe("redis plugin", function() {
 
           return previous;
         }, []);
-        assert.equal(messages.length, 10);
+        assert.equal(messages.length, 11);
       });
 
       it("does not add default config to the config object", function() {


### PR DESCRIPTION
## What Changed & Why

For my deploy process I'm tunnelling through an EC2 instance to an elasticache redis cluster with encryption-at-rest enabled. In order to connect to ssl redis instances, i need to be able to specify the tls configuration options for ioredis.

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]
