### PR TITLE
Allow rediss:// style urls for TLS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ module.exports = {
         if (!this.pluginConfig.url) {
           ['host', 'port'].forEach(this.applyDefaultConfigProperty.bind(this));
         } else {
-          var redisUrlRegexp = new RegExp('^redis://');
+          var redisUrlRegexp = new RegExp('^rediss?://');
 
           if (!this.pluginConfig.url.match(redisUrlRegexp)) {
             throw new Error(`Your Redis URL appears to be missing the "redis://" protocol. Update your URL to: redis://${this.pluginConfig.url}`);


### PR DESCRIPTION
Regexp should support `rediss://` style URLs for TLS support

This follows from https://github.com/ember-cli-deploy/ember-cli-deploy-redis/pull/88 specifically the last comment. Even if ioredis supports it, this addon currently blocks the use of `rediss://` because of the regexp check
