### PR TITLE
Allow specifying additional arguments to redis client

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ A Redis connection url to the Redis store
 
 *Example:* 'redis://some-user:some-password@some-host.com:1234'
 
+### redisOptions
+
+Options to be passed to the redis client.
+
+*Example:* { tls: { rejectUnauthorized: false } }
 ### filePattern
 
 A file matching this pattern will be uploaded to Redis.

--- a/index.js
+++ b/index.js
@@ -46,19 +46,20 @@ module.exports = {
           return context.commandOptions.revision || (context.revisionData && context.revisionData.revisionKey);
         },
         redisDeployClient(context, pluginHelper) {
-          var redisLib = context._redisLib;
-          var options = {
+          let redisLib = context._redisLib;
+          let libOptions = {
             url: pluginHelper.readConfig('url'),
             host: pluginHelper.readConfig('host'),
             port: pluginHelper.readConfig('port'),
             password: pluginHelper.readConfig('password'),
             database: pluginHelper.readConfig('database'),
+            redisOptions: pluginHelper.readConfig('redisOptions'),
             maxRecentUploads: pluginHelper.readConfig('maxRecentUploads'),
             allowOverwrite: pluginHelper.readConfig('allowOverwrite'),
             activationSuffix: pluginHelper.readConfig('activationSuffix')
           };
 
-          return new Redis(options, redisLib);
+          return new Redis(libOptions, redisLib);
         },
 
         revisionData(context) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -5,31 +5,33 @@ module.exports = CoreObject.extend({
 
   init(options, lib) {
     this._super();
-    var redisOptions = {};
-    var RedisLib     = lib;
-
+    let libOptions = {};
+    let RedisLib = lib;
     if (options.url) {
-      redisOptions = this._stripUsernameFromConfigUrl(options.url);
+      libOptions = { url: this._stripUsernameFromConfigUrl(options.url) };
     } else {
-      redisOptions = {
+      libOptions = {
         host: options.host,
         port: options.port
       };
 
       if (options.password) {
-        redisOptions.password = options.password;
+        libOptions.password = options.password;
       }
 
       if (options.database) {
-        redisOptions.db = options.database;
+        libOptions.db = options.database;
       }
+    }
+    if (options.redisOptions) {
+      libOptions = Object.assign(libOptions, options.redisOptions); 
     }
 
     if (!RedisLib) {
       RedisLib = require('ioredis');
     }
 
-    this._client = new RedisLib(redisOptions);
+    this._client = new RedisLib(libOptions);
 
     this._maxRecentUploads = options.maxRecentUploads || 10;
     this._allowOverwrite = options.allowOverwrite || false;

--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
         "infile": "CHANGELOG.md"
       }
     }
+  },
+  "volta": {
+    "node": "14.18.1",
+    "yarn": "1.22.17"
   }
 }

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -84,7 +84,8 @@ describe("redis plugin", function() {
           redis: {
             host: "somehost",
             port: 1234,
-            database: 4
+            database: 4,
+            redisOptions: { tls: { rejectUnauthorized: false }}
           }
         },
         _redisLib: redisLibStub
@@ -97,7 +98,8 @@ describe("redis plugin", function() {
         redisLibStub.calledWith({
           host: "somehost",
           port: 1234,
-          db: 4
+          db: 4,
+          tls: { rejectUnauthorized: false }
         })
       );
     });
@@ -125,7 +127,7 @@ describe("redis plugin", function() {
         plugin.readConfig("redisDeployClient");
 
         assert.isTrue(
-          redisLibStub.calledWith("redis://:password@host.amazonaws.com:6379/4")
+          redisLibStub.calledWith({ url: "redis://:password@host.amazonaws.com:6379/4" })
         );
       });
 
@@ -151,7 +153,7 @@ describe("redis plugin", function() {
         plugin.readConfig("redisDeployClient");
 
         assert.isTrue(
-          redisLibStub.calledWith("redis://:password@host.amazonaws.com:6379/4")
+          redisLibStub.calledWith({ url: "redis://:password@host.amazonaws.com:6379/4" })
         );
       });
 


### PR DESCRIPTION
## What Changed & Why

When using this plugin with Heroku Redis, you may get the following error:

```
[ioredis] Unhandled error event: Error: self signed certificate in certificate chain
```

This plugin allows specifying of options to be passed to the ioredis client via config. That would allow you to resolve the error above by setting the `redisOptions` config to `{ tls: { rejectUnauthorized: false } }`. Documentation of available ioredis options can be found [here](https://github.com/luin/ioredis/blob/master/API.md#new_Redis_new).

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)